### PR TITLE
Bringing your track in line with the latest changes to Problem Specifications

### DIFF
--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -1,0 +1,157 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
+description = "testing for eggs allergy -> not allergic to anything"
+
+[07ced27b-1da5-4c2e-8ae2-cb2791437546]
+description = "testing for eggs allergy -> allergic only to eggs"
+
+[5035b954-b6fa-4b9b-a487-dae69d8c5f96]
+description = "testing for eggs allergy -> allergic to eggs and something else"
+
+[64a6a83a-5723-4b5b-a896-663307403310]
+description = "testing for eggs allergy -> allergic to something, but not eggs"
+
+[90c8f484-456b-41c4-82ba-2d08d93231c6]
+description = "testing for eggs allergy -> allergic to everything"
+
+[d266a59a-fccc-413b-ac53-d57cb1f0db9d]
+description = "testing for peanuts allergy -> not allergic to anything"
+
+[ea210a98-860d-46b2-a5bf-50d8995b3f2a]
+description = "testing for peanuts allergy -> allergic only to peanuts"
+
+[eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
+description = "testing for peanuts allergy -> allergic to peanuts and something else"
+
+[9152058c-ce39-4b16-9b1d-283ec6d25085]
+description = "testing for peanuts allergy -> allergic to something, but not peanuts"
+
+[d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
+description = "testing for peanuts allergy -> allergic to everything"
+
+[b948b0a1-cbf7-4b28-a244-73ff56687c80]
+description = "testing for shellfish allergy -> not allergic to anything"
+
+[9ce9a6f3-53e9-4923-85e0-73019047c567]
+description = "testing for shellfish allergy -> allergic only to shellfish"
+
+[b272fca5-57ba-4b00-bd0c-43a737ab2131]
+description = "testing for shellfish allergy -> allergic to shellfish and something else"
+
+[21ef8e17-c227-494e-8e78-470a1c59c3d8]
+description = "testing for shellfish allergy -> allergic to something, but not shellfish"
+
+[cc789c19-2b5e-4c67-b146-625dc8cfa34e]
+description = "testing for shellfish allergy -> allergic to everything"
+
+[651bde0a-2a74-46c4-ab55-02a0906ca2f5]
+description = "testing for strawberries allergy -> not allergic to anything"
+
+[b649a750-9703-4f5f-b7f7-91da2c160ece]
+description = "testing for strawberries allergy -> allergic only to strawberries"
+
+[50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
+description = "testing for strawberries allergy -> allergic to strawberries and something else"
+
+[23dd6952-88c9-48d7-a7d5-5d0343deb18d]
+description = "testing for strawberries allergy -> allergic to something, but not strawberries"
+
+[74afaae2-13b6-43a2-837a-286cd42e7d7e]
+description = "testing for strawberries allergy -> allergic to everything"
+
+[c49a91ef-6252-415e-907e-a9d26ef61723]
+description = "testing for tomatoes allergy -> not allergic to anything"
+
+[b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
+description = "testing for tomatoes allergy -> allergic only to tomatoes"
+
+[1ca50eb1-f042-4ccf-9050-341521b929ec]
+description = "testing for tomatoes allergy -> allergic to tomatoes and something else"
+
+[e9846baa-456b-4eff-8025-034b9f77bd8e]
+description = "testing for tomatoes allergy -> allergic to something, but not tomatoes"
+
+[b2414f01-f3ad-4965-8391-e65f54dad35f]
+description = "testing for tomatoes allergy -> allergic to everything"
+
+[978467ab-bda4-49f7-b004-1d011ead947c]
+description = "testing for chocolate allergy -> not allergic to anything"
+
+[59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
+description = "testing for chocolate allergy -> allergic only to chocolate"
+
+[b0a7c07b-2db7-4f73-a180-565e07040ef1]
+description = "testing for chocolate allergy -> allergic to chocolate and something else"
+
+[f5506893-f1ae-482a-b516-7532ba5ca9d2]
+description = "testing for chocolate allergy -> allergic to something, but not chocolate"
+
+[02debb3d-d7e2-4376-a26b-3c974b6595c6]
+description = "testing for chocolate allergy -> allergic to everything"
+
+[17f4a42b-c91e-41b8-8a76-4797886c2d96]
+description = "testing for pollen allergy -> not allergic to anything"
+
+[7696eba7-1837-4488-882a-14b7b4e3e399]
+description = "testing for pollen allergy -> allergic only to pollen"
+
+[9a49aec5-fa1f-405d-889e-4dfc420db2b6]
+description = "testing for pollen allergy -> allergic to pollen and something else"
+
+[3cb8e79f-d108-4712-b620-aa146b1954a9]
+description = "testing for pollen allergy -> allergic to something, but not pollen"
+
+[1dc3fe57-7c68-4043-9d51-5457128744b2]
+description = "testing for pollen allergy -> allergic to everything"
+
+[d3f523d6-3d50-419b-a222-d4dfd62ce314]
+description = "testing for cats allergy -> not allergic to anything"
+
+[eba541c3-c886-42d3-baef-c048cb7fcd8f]
+description = "testing for cats allergy -> allergic only to cats"
+
+[ba718376-26e0-40b7-bbbe-060287637ea5]
+description = "testing for cats allergy -> allergic to cats and something else"
+
+[3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
+description = "testing for cats allergy -> allergic to something, but not cats"
+
+[1faabb05-2b98-4995-9046-d83e4a48a7c1]
+description = "testing for cats allergy -> allergic to everything"
+
+[f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
+description = "list when: -> no allergies"
+
+[9e1a4364-09a6-4d94-990f-541a94a4c1e8]
+description = "list when: -> just eggs"
+
+[8851c973-805e-4283-9e01-d0c0da0e4695]
+description = "list when: -> just peanuts"
+
+[2c8943cb-005e-435f-ae11-3e8fb558ea98]
+description = "list when: -> just strawberries"
+
+[6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
+description = "list when: -> eggs and peanuts"
+
+[19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
+description = "list when: -> more than eggs but not peanuts"
+
+[4b68f470-067c-44e4-889f-c9fe28917d2f]
+description = "list when: -> lots of stuff"
+
+[0881b7c5-9efa-4530-91bd-68370d054bc7]
+description = "list when: -> everything"
+
+[12ce86de-b347-42a0-ab7c-2e0570f0c65b]
+description = "list when: -> no allergen score parts"

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,0 +1,56 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[dd40c4d2-3c8b-44e5-992a-f42b393ec373]
+description = "no matches"
+
+[b3cca662-f50a-489e-ae10-ab8290a09bdc]
+description = "detects two anagrams"
+
+[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+description = "detects two anagrams"
+reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
+
+[a27558ee-9ba0-4552-96b1-ecf665b06556]
+description = "does not detect anagram subsets"
+
+[64cd4584-fc15-4781-b633-3d814c4941a4]
+description = "detects anagram"
+
+[99c91beb-838f-4ccd-b123-935139917283]
+description = "detects three anagrams"
+
+[78487770-e258-4e1f-a646-8ece10950d90]
+description = "detects multiple anagrams with different case"
+
+[1d0ab8aa-362f-49b7-9902-3d0c668d557b]
+description = "does not detect non-anagrams with identical checksum"
+
+[9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
+description = "detects anagrams case-insensitively"
+
+[b248e49f-0905-48d2-9c8d-bd02d8c3e392]
+description = "detects anagrams using case-insensitive subject"
+
+[f367325c-78ec-411c-be76-e79047f4bd54]
+description = "detects anagrams using case-insensitive possible matches"
+
+[7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
+description = "does not detect an anagram if the original word is repeated"
+
+[9878a1c9-d6ea-4235-ae51-3ea2befd6842]
+description = "anagrams must use all letters exactly once"
+
+[85757361-4535-45fd-ac0e-3810d40debc1]
+description = "words are not anagrams of themselves (case-insensitive)"
+
+[a0705568-628c-4b55-9798-82e4acde51ca]
+description = "words other than themselves can be anagrams"

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c1ed103c-258d-45b2-be73-d8c6d9580c7b]
+description = "Zero is an Armstrong number"
+
+[579e8f03-9659-4b85-a1a2-d64350f6b17a]
+description = "Single digit numbers are Armstrong numbers"
+
+[2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
+description = "There are no 2 digit Armstrong numbers"
+
+[509c087f-e327-4113-a7d2-26a4e9d18283]
+description = "Three digit number that is an Armstrong number"
+
+[7154547d-c2ce-468d-b214-4cb953b870cf]
+description = "Three digit number that is not an Armstrong number"
+
+[6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
+description = "Four digit number that is an Armstrong number"
+
+[eed4b331-af80-45b5-a80b-19c9ea444b2e]
+description = "Four digit number that is not an Armstrong number"
+
+[f971ced7-8d68-4758-aea1-d4194900b864]
+description = "Seven digit number that is an Armstrong number"
+
+[7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
+description = "Seven digit number that is not an Armstrong number"

--- a/exercises/practice/beer-song/.meta/tests.toml
+++ b/exercises/practice/beer-song/.meta/tests.toml
@@ -1,0 +1,34 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[5a02fd08-d336-4607-8006-246fe6fa9fb0]
+description = "verse -> single verse -> first generic verse"
+
+[77299ca6-545e-4217-a9cc-606b342e0187]
+description = "verse -> single verse -> last generic verse"
+
+[102cbca0-b197-40fd-b548-e99609b06428]
+description = "verse -> single verse -> verse with 2 bottles"
+
+[b8ef9fce-960e-4d85-a0c9-980a04ec1972]
+description = "verse -> single verse -> verse with 1 bottle"
+
+[c59d4076-f671-4ee3-baaa-d4966801f90d]
+description = "verse -> single verse -> verse with 0 bottles"
+
+[7e17c794-402d-4ca6-8f96-4d8f6ee1ec7e]
+description = "lyrics -> multiple verses -> first two verses"
+
+[949868e7-67e8-43d3-9bb4-69277fe020fb]
+description = "lyrics -> multiple verses -> last three verses"
+
+[bc220626-126c-4e72-8df4-fddfc0c3e458]
+description = "lyrics -> multiple verses -> all verses"

--- a/exercises/practice/binary-search-tree/.meta/tests.toml
+++ b/exercises/practice/binary-search-tree/.meta/tests.toml
@@ -1,31 +1,40 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# data is retained
-"e9c93a78-c536-4750-a336-94583d23fafa" = true
+[e9c93a78-c536-4750-a336-94583d23fafa]
+description = "data is retained"
 
-# smaller number at left node
-"7a95c9e8-69f6-476a-b0c4-4170cb3f7c91" = true
+[7a95c9e8-69f6-476a-b0c4-4170cb3f7c91]
+description = "insert data at proper node -> smaller number at left node"
 
-# same number at left node
-"22b89499-9805-4703-a159-1a6e434c1585" = true
+[22b89499-9805-4703-a159-1a6e434c1585]
+description = "insert data at proper node -> same number at left node"
 
-# greater number at right node
-"2e85fdde-77b1-41ed-b6ac-26ce6b663e34" = true
+[2e85fdde-77b1-41ed-b6ac-26ce6b663e34]
+description = "insert data at proper node -> greater number at right node"
 
-# can create complex tree
-"dd898658-40ab-41d0-965e-7f145bf66e0b" = true
+[dd898658-40ab-41d0-965e-7f145bf66e0b]
+description = "can create complex tree"
 
-# can sort single number
-"9e0c06ef-aeca-4202-b8e4-97f1ed057d56" = true
+[9e0c06ef-aeca-4202-b8e4-97f1ed057d56]
+description = "can sort data -> can sort single number"
 
-# can sort if second number is smaller than first
-"425e6d07-fceb-4681-a4f4-e46920e380bb" = true
+[425e6d07-fceb-4681-a4f4-e46920e380bb]
+description = "can sort data -> can sort if second number is smaller than first"
 
-# can sort if second number is same as first
-"bd7532cc-6988-4259-bac8-1d50140079ab" = true
+[bd7532cc-6988-4259-bac8-1d50140079ab]
+description = "can sort data -> can sort if second number is same as first"
 
-# can sort if second number is greater than first
-"b6d1b3a5-9d79-44fd-9013-c83ca92ddd36" = true
+[b6d1b3a5-9d79-44fd-9013-c83ca92ddd36]
+description = "can sort data -> can sort if second number is greater than first"
 
-# can sort complex tree
-"d00ec9bd-1288-4171-b968-d44d0808c1c8" = true
+[d00ec9bd-1288-4171-b968-d44d0808c1c8]
+description = "can sort data -> can sort complex tree"

--- a/exercises/practice/binary-search/.meta/tests.toml
+++ b/exercises/practice/binary-search/.meta/tests.toml
@@ -1,34 +1,43 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# finds a value in an array with one element
-"b55c24a9-a98d-4379-a08c-2adcf8ebeee8" = true
+[b55c24a9-a98d-4379-a08c-2adcf8ebeee8]
+description = "finds a value in an array with one element"
 
-# finds a value in the middle of an array
-"73469346-b0a0-4011-89bf-989e443d503d" = true
+[73469346-b0a0-4011-89bf-989e443d503d]
+description = "finds a value in the middle of an array"
 
-# finds a value at the beginning of an array
-"327bc482-ab85-424e-a724-fb4658e66ddb" = true
+[327bc482-ab85-424e-a724-fb4658e66ddb]
+description = "finds a value at the beginning of an array"
 
-# finds a value at the end of an array
-"f9f94b16-fe5e-472c-85ea-c513804c7d59" = true
+[f9f94b16-fe5e-472c-85ea-c513804c7d59]
+description = "finds a value at the end of an array"
 
-# finds a value in an array of odd length
-"f0068905-26e3-4342-856d-ad153cadb338" = true
+[f0068905-26e3-4342-856d-ad153cadb338]
+description = "finds a value in an array of odd length"
 
-# finds a value in an array of even length
-"fc316b12-c8b3-4f5e-9e89-532b3389de8c" = true
+[fc316b12-c8b3-4f5e-9e89-532b3389de8c]
+description = "finds a value in an array of even length"
 
-# identifies that a value is not included in the array
-"da7db20a-354f-49f7-a6a1-650a54998aa6" = true
+[da7db20a-354f-49f7-a6a1-650a54998aa6]
+description = "identifies that a value is not included in the array"
 
-# a value smaller than the array's smallest value is not found
-"95d869ff-3daf-4c79-b622-6e805c675f97" = true
+[95d869ff-3daf-4c79-b622-6e805c675f97]
+description = "a value smaller than the array's smallest value is not found"
 
-# a value larger than the array's largest value is not found
-"8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba" = true
+[8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba]
+description = "a value larger than the array's largest value is not found"
 
-# nothing is found in an empty array
-"f439a0fa-cf42-4262-8ad1-64bf41ce566a" = true
+[f439a0fa-cf42-4262-8ad1-64bf41ce566a]
+description = "nothing is found in an empty array"
 
-# nothing is found when the left and right bounds cross
-"2c353967-b56d-40b8-acff-ce43115eed64" = true
+[2c353967-b56d-40b8-acff-ce43115eed64]
+description = "nothing is found when the left and right bounds cross"

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -1,0 +1,85 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e162fead-606f-437a-a166-d051915cea8e]
+description = "stating something"
+
+[73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
+description = "shouting"
+
+[d6c98afd-df35-4806-b55e-2c457c3ab748]
+description = "shouting gibberish"
+
+[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
+description = "asking a question"
+
+[81080c62-4e4d-4066-b30a-48d8d76920d9]
+description = "asking a numeric question"
+
+[2a02716d-685b-4e2e-a804-2adaf281c01e]
+description = "asking gibberish"
+
+[c02f9179-ab16-4aa7-a8dc-940145c385f7]
+description = "talking forcefully"
+
+[153c0e25-9bb5-4ec5-966e-598463658bcd]
+description = "using acronyms in regular speech"
+
+[a5193c61-4a92-4f68-93e2-f554eb385ec6]
+description = "forceful question"
+
+[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
+description = "shouting numbers"
+
+[f7bc4b92-bdff-421e-a238-ae97f230ccac]
+description = "no letters"
+
+[bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
+description = "question with no letters"
+
+[496143c8-1c31-4c01-8a08-88427af85c66]
+description = "shouting with special characters"
+
+[e6793c1c-43bd-4b8d-bc11-499aea73925f]
+description = "shouting with no exclamation mark"
+
+[aa8097cc-c548-4951-8856-14a404dd236a]
+description = "statement containing question mark"
+
+[9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
+description = "non-letters with question"
+
+[8608c508-f7de-4b17-985b-811878b3cf45]
+description = "prattling on"
+
+[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
+description = "silence"
+
+[d6c47565-372b-4b09-b1dd-c40552b8378b]
+description = "prolonged silence"
+
+[4428f28d-4100-4d85-a902-e5a78cb0ecd3]
+description = "alternate silence"
+
+[66953780-165b-4e7e-8ce3-4bcb80b6385a]
+description = "multiple line question"
+
+[5371ef75-d9ea-4103-bcfa-2da973ddec1b]
+description = "starting with whitespace"
+
+[05b304d6-f83b-46e7-81e0-4cd3ca647900]
+description = "ending with whitespace"
+
+[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
+description = "other whitespace"
+
+[12983553-8601-46a8-92fa-fcaa3bc4a2a0]
+description = "non-question ending with whitespace"

--- a/exercises/practice/clock/.meta/tests.toml
+++ b/exercises/practice/clock/.meta/tests.toml
@@ -1,0 +1,166 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[a577bacc-106b-496e-9792-b3083ea8705e]
+description = "Create a new clock with an initial time -> on the hour"
+
+[b5d0c360-3b88-489b-8e84-68a1c7a4fa23]
+description = "Create a new clock with an initial time -> past the hour"
+
+[473223f4-65f3-46ff-a9f7-7663c7e59440]
+description = "Create a new clock with an initial time -> midnight is zero hours"
+
+[ca95d24a-5924-447d-9a96-b91c8334725c]
+description = "Create a new clock with an initial time -> hour rolls over"
+
+[f3826de0-0925-4d69-8ac8-89aea7e52b78]
+description = "Create a new clock with an initial time -> hour rolls over continuously"
+
+[a02f7edf-dfd4-4b11-b21a-86de3cc6a95c]
+description = "Create a new clock with an initial time -> sixty minutes is next hour"
+
+[8f520df6-b816-444d-b90f-8a477789beb5]
+description = "Create a new clock with an initial time -> minutes roll over"
+
+[c75c091b-47ac-4655-8d40-643767fc4eed]
+description = "Create a new clock with an initial time -> minutes roll over continuously"
+
+[06343ecb-cf39-419d-a3f5-dcbae0cc4c57]
+description = "Create a new clock with an initial time -> hour and minutes roll over"
+
+[be60810e-f5d9-4b58-9351-a9d1e90e660c]
+description = "Create a new clock with an initial time -> hour and minutes roll over continuously"
+
+[1689107b-0b5c-4bea-aad3-65ec9859368a]
+description = "Create a new clock with an initial time -> hour and minutes roll over to exactly midnight"
+
+[d3088ee8-91b7-4446-9e9d-5e2ad6219d91]
+description = "Create a new clock with an initial time -> negative hour"
+
+[77ef6921-f120-4d29-bade-80d54aa43b54]
+description = "Create a new clock with an initial time -> negative hour rolls over"
+
+[359294b5-972f-4546-bb9a-a85559065234]
+description = "Create a new clock with an initial time -> negative hour rolls over continuously"
+
+[509db8b7-ac19-47cc-bd3a-a9d2f30b03c0]
+description = "Create a new clock with an initial time -> negative minutes"
+
+[5d6bb225-130f-4084-84fd-9e0df8996f2a]
+description = "Create a new clock with an initial time -> negative minutes roll over"
+
+[d483ceef-b520-4f0c-b94a-8d2d58cf0484]
+description = "Create a new clock with an initial time -> negative minutes roll over continuously"
+
+[1cd19447-19c6-44bf-9d04-9f8305ccb9ea]
+description = "Create a new clock with an initial time -> negative sixty minutes is previous hour"
+
+[9d3053aa-4f47-4afc-bd45-d67a72cef4dc]
+description = "Create a new clock with an initial time -> negative hour and minutes both roll over"
+
+[51d41fcf-491e-4ca0-9cae-2aa4f0163ad4]
+description = "Create a new clock with an initial time -> negative hour and minutes both roll over continuously"
+
+[d098e723-ad29-4ef9-997a-2693c4c9d89a]
+description = "Add minutes -> add minutes"
+
+[b6ec8f38-e53e-4b22-92a7-60dab1f485f4]
+description = "Add minutes -> add no minutes"
+
+[efd349dd-0785-453e-9ff8-d7452a8e7269]
+description = "Add minutes -> add to next hour"
+
+[749890f7-aba9-4702-acce-87becf4ef9fe]
+description = "Add minutes -> add more than one hour"
+
+[da63e4c1-1584-46e3-8d18-c9dc802c1713]
+description = "Add minutes -> add more than two hours with carry"
+
+[be167a32-3d33-4cec-a8bc-accd47ddbb71]
+description = "Add minutes -> add across midnight"
+
+[6672541e-cdae-46e4-8be7-a820cc3be2a8]
+description = "Add minutes -> add more than one day (1500 min = 25 hrs)"
+
+[1918050d-c79b-4cb7-b707-b607e2745c7e]
+description = "Add minutes -> add more than two days"
+
+[37336cac-5ede-43a5-9026-d426cbe40354]
+description = "Subtract minutes -> subtract minutes"
+
+[0aafa4d0-3b5f-4b12-b3af-e3a9e09c047b]
+description = "Subtract minutes -> subtract to previous hour"
+
+[9b4e809c-612f-4b15-aae0-1df0acb801b9]
+description = "Subtract minutes -> subtract more than an hour"
+
+[8b04bb6a-3d33-4e6c-8de9-f5de6d2c70d6]
+description = "Subtract minutes -> subtract across midnight"
+
+[07c3bbf7-ce4d-4658-86e8-4a77b7a5ccd9]
+description = "Subtract minutes -> subtract more than two hours"
+
+[90ac8a1b-761c-4342-9c9c-cdc3ed5db097]
+description = "Subtract minutes -> subtract more than two hours with borrow"
+
+[2149f985-7136-44ad-9b29-ec023a97a2b7]
+description = "Subtract minutes -> subtract more than one day (1500 min = 25 hrs)"
+
+[ba11dbf0-ac27-4acb-ada9-3b853ec08c97]
+description = "Subtract minutes -> subtract more than two days"
+
+[f2fdad51-499f-4c9b-a791-b28c9282e311]
+description = "Compare two clocks for equality -> clocks with same time"
+
+[5d409d4b-f862-4960-901e-ec430160b768]
+description = "Compare two clocks for equality -> clocks a minute apart"
+
+[a6045fcf-2b52-4a47-8bb2-ef10a064cba5]
+description = "Compare two clocks for equality -> clocks an hour apart"
+
+[66b12758-0be5-448b-a13c-6a44bce83527]
+description = "Compare two clocks for equality -> clocks with hour overflow"
+
+[2b19960c-212e-4a71-9aac-c581592f8111]
+description = "Compare two clocks for equality -> clocks with hour overflow by several days"
+
+[6f8c6541-afac-4a92-b0c2-b10d4e50269f]
+description = "Compare two clocks for equality -> clocks with negative hour"
+
+[bb9d5a68-e324-4bf5-a75e-0e9b1f97a90d]
+description = "Compare two clocks for equality -> clocks with negative hour that wraps"
+
+[56c0326d-565b-4d19-a26f-63b3205778b7]
+description = "Compare two clocks for equality -> clocks with negative hour that wraps multiple times"
+
+[c90b9de8-ddff-4ffe-9858-da44a40fdbc2]
+description = "Compare two clocks for equality -> clocks with minute overflow"
+
+[533a3dc5-59a7-491b-b728-a7a34fe325de]
+description = "Compare two clocks for equality -> clocks with minute overflow by several days"
+
+[fff49e15-f7b7-4692-a204-0f6052d62636]
+description = "Compare two clocks for equality -> clocks with negative minute"
+
+[605c65bb-21bd-43eb-8f04-878edf508366]
+description = "Compare two clocks for equality -> clocks with negative minute that wraps"
+
+[b87e64ed-212a-4335-91fd-56da8421d077]
+description = "Compare two clocks for equality -> clocks with negative minute that wraps multiple times"
+
+[822fbf26-1f3b-4b13-b9bf-c914816b53dd]
+description = "Compare two clocks for equality -> clocks with negative hours and minutes"
+
+[e787bccd-cf58-4a1d-841c-ff80eaaccfaa]
+description = "Compare two clocks for equality -> clocks with negative hours and minutes that wrap"
+
+[96969ca8-875a-48a1-86ae-257a528c44f5]
+description = "Compare two clocks for equality -> full clock and zeroed clock"

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,0 +1,61 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
+description = "empty strands"
+
+[54681314-eee2-439a-9db0-b0636c656156]
+description = "single letter identical strands"
+
+[294479a3-a4c8-478f-8d63-6209815a827b]
+description = "single letter different strands"
+
+[9aed5f34-5693-4344-9b31-40c692fb5592]
+description = "long identical strands"
+
+[cd2273a5-c576-46c8-a52b-dee251c3e6e5]
+description = "long different strands"
+
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
+
+[b9228bb1-465f-4141-b40f-1f99812de5a8]
+description = "disallow first strand longer"
+reimplements = "919f8ef0-b767-4d1b-8516-6379d07fcb28"
+
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
+
+[dab38838-26bb-4fff-acbe-3b0a9bfeba2d]
+description = "disallow second strand longer"
+reimplements = "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e"
+
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
+
+[db92e77e-7c72-499d-8fe6-9354d2bfd504]
+description = "disallow left empty strand"
+reimplements = "5dce058b-28d4-4ca7-aa64-adfe4e17784c"
+
+[b764d47c-83ff-4de2-ab10-6cfe4b15c0f3]
+description = "disallow empty first strand"
+reimplements = "db92e77e-7c72-499d-8fe6-9354d2bfd504"
+
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"
+
+[920cd6e3-18f4-4143-b6b8-74270bb8f8a3]
+description = "disallow right empty strand"
+reimplements = "38826d4b-16fb-4639-ac3e-ba027dec8b5f"
+
+[9ab9262f-3521-4191-81f5-0ed184a5aa89]
+description = "disallow empty second strand"
+reimplements = "920cd6e3-18f4-4143-b6b8-74270bb8f8a3"

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,0 +1,13 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"

--- a/exercises/practice/isbn-verifier/.meta/tests.toml
+++ b/exercises/practice/isbn-verifier/.meta/tests.toml
@@ -1,0 +1,61 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[0caa3eac-d2e3-4c29-8df8-b188bc8c9292]
+description = "valid isbn"
+
+[19f76b53-7c24-45f8-87b8-4604d0ccd248]
+description = "invalid isbn check digit"
+
+[4164bfee-fb0a-4a1c-9f70-64c6a1903dcd]
+description = "valid isbn with a check digit of 10"
+
+[3ed50db1-8982-4423-a993-93174a20825c]
+description = "check digit is a character other than X"
+
+[c19ba0c4-014f-4dc3-a63f-ff9aefc9b5ec]
+description = "invalid character in isbn"
+
+[28025280-2c39-4092-9719-f3234b89c627]
+description = "X is only valid as a check digit"
+
+[f6294e61-7e79-46b3-977b-f48789a4945b]
+description = "valid isbn without separating dashes"
+
+[185ab99b-3a1b-45f3-aeec-b80d80b07f0b]
+description = "isbn without separating dashes and X as check digit"
+
+[7725a837-ec8e-4528-a92a-d981dd8cf3e2]
+description = "isbn without check digit and dashes"
+
+[47e4dfba-9c20-46ed-9958-4d3190630bdf]
+description = "too long isbn and no dashes"
+
+[737f4e91-cbba-4175-95bf-ae630b41fb60]
+description = "too short isbn"
+
+[5458a128-a9b6-4ff8-8afb-674e74567cef]
+description = "isbn without check digit"
+
+[70b6ad83-d0a2-4ca7-a4d5-a9ab731800f7]
+description = "check digit of X should not be used for 0"
+
+[94610459-55ab-4c35-9b93-ff6ea1a8e562]
+description = "empty isbn"
+
+[7bff28d4-d770-48cc-80d6-b20b3a0fb46c]
+description = "input is 9 characters"
+
+[ed6e8d1b-382c-4081-8326-8b772c581fec]
+description = "invalid characters are not ignored"
+
+[fb5e48d8-7c03-4bfb-a088-b101df16fdc3]
+description = "input is too long but contains a valid isbn"

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[a0e97d2d-669e-47c7-8134-518a1e2c4555]
+description = "empty string"
+
+[9a001b50-f194-4143-bc29-2af5ec1ef652]
+description = "isogram with only lower case characters"
+
+[8ddb0ca3-276e-4f8b-89da-d95d5bae78a4]
+description = "word with one duplicated character"
+
+[6450b333-cbc2-4b24-a723-0b459b34fe18]
+description = "word with one duplicated character from the end of the alphabet"
+
+[a15ff557-dd04-4764-99e7-02cc1a385863]
+description = "longest reported english isogram"
+
+[f1a7f6c7-a42f-4915-91d7-35b2ea11c92e]
+description = "word with duplicated character in mixed case"
+
+[14a4f3c1-3b47-4695-b645-53d328298942]
+description = "word with duplicated character in mixed case, lowercase first"
+
+[423b850c-7090-4a8a-b057-97f1cadd7c42]
+description = "hypothetical isogrammic word with hyphen"
+
+[93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2]
+description = "hypothetical word with duplicated character following hyphen"
+
+[36b30e5c-173f-49c6-a515-93a3e825553f]
+description = "isogram with duplicated hyphen"
+
+[cdabafa0-c9f4-4c1f-b142-689c6ee17d93]
+description = "made-up name that is an isogram"
+
+[5fc61048-d74e-48fd-bc34-abfc21552d4d]
+description = "duplicated character in the middle"
+
+[310ac53d-8932-47bc-bbb4-b2b94f25a83e]
+description = "same first and last characters"
+
+[0d0b8644-0a1e-4a31-a432-2b3ee270d847]
+description = "word with duplicated character and with two hyphens"

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
+
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
+
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
+
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
+
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
+
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap year"
+
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 is leap year"
+
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
+
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -1,52 +1,61 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# paired square brackets
-"81ec11da-38dd-442a-bcf9-3de7754609a5" = true
+[81ec11da-38dd-442a-bcf9-3de7754609a5]
+description = "paired square brackets"
 
-# empty string
-"287f0167-ac60-4b64-8452-a0aa8f4e5238" = true
+[287f0167-ac60-4b64-8452-a0aa8f4e5238]
+description = "empty string"
 
-# unpaired brackets
-"6c3615a3-df01-4130-a731-8ef5f5d78dac" = true
+[6c3615a3-df01-4130-a731-8ef5f5d78dac]
+description = "unpaired brackets"
 
-# wrong ordered brackets
-"9d414171-9b98-4cac-a4e5-941039a97a77" = true
+[9d414171-9b98-4cac-a4e5-941039a97a77]
+description = "wrong ordered brackets"
 
-# wrong closing bracket
-"f0f97c94-a149-4736-bc61-f2c5148ffb85" = true
+[f0f97c94-a149-4736-bc61-f2c5148ffb85]
+description = "wrong closing bracket"
 
-# paired with whitespace
-"754468e0-4696-4582-a30e-534d47d69756" = true
+[754468e0-4696-4582-a30e-534d47d69756]
+description = "paired with whitespace"
 
-# partially paired brackets
-"ba84f6ee-8164-434a-9c3e-b02c7f8e8545" = true
+[ba84f6ee-8164-434a-9c3e-b02c7f8e8545]
+description = "partially paired brackets"
 
-# simple nested brackets
-"3c86c897-5ff3-4a2b-ad9b-47ac3a30651d" = true
+[3c86c897-5ff3-4a2b-ad9b-47ac3a30651d]
+description = "simple nested brackets"
 
-# several paired brackets
-"2d137f2c-a19e-4993-9830-83967a2d4726" = true
+[2d137f2c-a19e-4993-9830-83967a2d4726]
+description = "several paired brackets"
 
-# paired and nested brackets
-"2e1f7b56-c137-4c92-9781-958638885a44" = true
+[2e1f7b56-c137-4c92-9781-958638885a44]
+description = "paired and nested brackets"
 
-# unopened closing brackets
-"84f6233b-e0f7-4077-8966-8085d295c19b" = true
+[84f6233b-e0f7-4077-8966-8085d295c19b]
+description = "unopened closing brackets"
 
-# unpaired and nested brackets
-"9b18c67d-7595-4982-b2c5-4cb949745d49" = true
+[9b18c67d-7595-4982-b2c5-4cb949745d49]
+description = "unpaired and nested brackets"
 
-# paired and wrong nested brackets
-"a0205e34-c2ac-49e6-a88a-899508d7d68e" = true
+[a0205e34-c2ac-49e6-a88a-899508d7d68e]
+description = "paired and wrong nested brackets"
 
-# paired and incomplete brackets
-"ef47c21b-bcfd-4998-844c-7ad5daad90a8" = true
+[ef47c21b-bcfd-4998-844c-7ad5daad90a8]
+description = "paired and incomplete brackets"
 
-# too many closing brackets
-"a4675a40-a8be-4fc2-bc47-2a282ce6edbe" = true
+[a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
+description = "too many closing brackets"
 
-# math expression
-"99255f93-261b-4435-a352-02bdecc9bdf2" = true
+[99255f93-261b-4435-a352-02bdecc9bdf2]
+description = "math expression"
 
-# complex latex expression
-"8e357d79-f302-469a-8515-2561877256a1" = true
+[8e357d79-f302-469a-8515-2561877256a1]
+description = "complex latex expression"

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -1,0 +1,25 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[3e5c30a8-87e2-4845-a815-a49671ade970]
+description = "empty strand"
+
+[a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
+description = "can count one nucleotide in single-character input"
+
+[eca0d565-ed8c-43e7-9033-6cefbf5115b5]
+description = "strand with repeated nucleotide"
+
+[40a45eac-c83f-4740-901a-20b22d15a39f]
+description = "strand with multiple nucleotides"
+
+[b4c47851-ee9e-4b0a-be70-a86e343bd851]
+description = "strand with invalid nucleotides"

--- a/exercises/practice/pascals-triangle/.meta/tests.toml
+++ b/exercises/practice/pascals-triangle/.meta/tests.toml
@@ -1,25 +1,34 @@
-[canonical-tests]
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
-# zero rows
-"9920ce55-9629-46d5-85d6-4201f4a4234d" = true
+[9920ce55-9629-46d5-85d6-4201f4a4234d]
+description = "zero rows"
 
-# single row
-"70d643ce-a46d-4e93-af58-12d88dd01f21" = true
+[70d643ce-a46d-4e93-af58-12d88dd01f21]
+description = "single row"
 
-# two rows
-"a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd" = true
+[a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd]
+description = "two rows"
 
-# three rows
-"97206a99-79ba-4b04-b1c5-3c0fa1e16925" = true
+[97206a99-79ba-4b04-b1c5-3c0fa1e16925]
+description = "three rows"
 
-# four rows
-"565a0431-c797-417c-a2c8-2935e01ce306" = true
+[565a0431-c797-417c-a2c8-2935e01ce306]
+description = "four rows"
 
-# five rows
-"06f9ea50-9f51-4eb2-b9a9-c00975686c27" = true
+[06f9ea50-9f51-4eb2-b9a9-c00975686c27]
+description = "five rows"
 
-# six rows
-"c3912965-ddb4-46a9-848e-3363e6b00b13" = true
+[c3912965-ddb4-46a9-848e-3363e6b00b13]
+description = "six rows"
 
-# ten rows
-"6cb26c66-7b57-4161-962c-81ec8c99f16b" = true
+[6cb26c66-7b57-4161-962c-81ec8c99f16b]
+description = "ten rows"

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -1,0 +1,64 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[79666dce-e0f1-46de-95a1-563802913c35]
+description = "cleans the number"
+
+[c360451f-549f-43e4-8aba-fdf6cb0bf83f]
+description = "cleans numbers with dots"
+
+[08f94c34-9a37-46a2-a123-2a8e9727395d]
+description = "cleans numbers with multiple spaces"
+
+[598d8432-0659-4019-a78b-1c6a73691d21]
+description = "invalid when 9 digits"
+
+[57061c72-07b5-431f-9766-d97da7c4399d]
+description = "invalid when 11 digits does not start with a 1"
+
+[9962cbf3-97bb-4118-ba9b-38ff49c64430]
+description = "valid when 11 digits and starting with 1"
+
+[fa724fbf-054c-4d91-95da-f65ab5b6dbca]
+description = "valid when 11 digits and starting with 1 even with punctuation"
+
+[c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
+description = "invalid when more than 11 digits"
+
+[63f38f37-53f6-4a5f-bd86-e9b404f10a60]
+description = "invalid with letters"
+
+[4bd97d90-52fd-45d3-b0db-06ab95b1244e]
+description = "invalid with punctuations"
+
+[d77d07f8-873c-4b17-8978-5f66139bf7d7]
+description = "invalid if area code starts with 0"
+
+[c7485cfb-1e7b-4081-8e96-8cdb3b77f15e]
+description = "invalid if area code starts with 1"
+
+[4d622293-6976-413d-b8bf-dd8a94d4e2ac]
+description = "invalid if exchange code starts with 0"
+
+[4cef57b4-7d8e-43aa-8328-1e1b89001262]
+description = "invalid if exchange code starts with 1"
+
+[9925b09c-1a0d-4960-a197-5d163cbe308c]
+description = "invalid if area code starts with 0 on valid 11-digit number"
+
+[3f809d37-40f3-44b5-ad90-535838b1a816]
+description = "invalid if area code starts with 1 on valid 11-digit number"
+
+[e08e5532-d621-40d4-b0cc-96c159276b65]
+description = "invalid if exchange code starts with 0 on valid 11-digit number"
+
+[57b32f3d-696a-455c-8bf1-137b6d171cdf]
+description = "invalid if exchange code starts with 1 on valid 11-digit number"

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,0 +1,64 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1575d549-e502-46d4-a8e1-6b7bec6123d8]
+description = "the sound for 1 is 1"
+
+[1f51a9f9-4895-4539-b182-d7b0a5ab2913]
+description = "the sound for 3 is Pling"
+
+[2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
+description = "the sound for 5 is Plang"
+
+[d7e60daa-32ef-4c23-b688-2abff46c4806]
+description = "the sound for 7 is Plong"
+
+[6bb4947b-a724-430c-923f-f0dc3d62e56a]
+description = "the sound for 6 is Pling as it has a factor 3"
+
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
+
+[0dd66175-e3e2-47fc-8750-d01739856671]
+description = "the sound for 9 is Pling as it has a factor 3"
+
+[022c44d3-2182-4471-95d7-c575af225c96]
+description = "the sound for 10 is Plang as it has a factor 5"
+
+[37ab74db-fed3-40ff-b7b9-04acdfea8edf]
+description = "the sound for 14 is Plong as it has a factor of 7"
+
+[31f92999-6afb-40ee-9aa4-6d15e3334d0f]
+description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
+
+[ff9bb95d-6361-4602-be2c-653fe5239b54]
+description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
+
+[d2e75317-b72e-40ab-8a64-6734a21dece1]
+description = "the sound for 25 is Plang as it has a factor 5"
+
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
+
+[bdf061de-8564-4899-a843-14b48b722789]
+description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
+
+[c4680bee-69ba-439d-99b5-70c5fd1a7a83]
+description = "the sound for 49 is Plong as it has a factor 7"
+
+[17f2bc9a-b65a-4d23-8ccd-266e8c271444]
+description = "the sound for 52 is 52"
+
+[e46677ed-ff1a-419f-a740-5c713d2830e4]
+description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
+
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c3b7d806-dced-49ee-8543-933fd1719b1c]
+description = "an empty string"
+
+[01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
+description = "a word"
+
+[0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
+description = "a capitalized word"
+
+[71854b9c-f200-4469-9f5c-1e8e5eff5614]
+description = "a sentence with punctuation"
+
+[1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
+description = "a palindrome"
+
+[b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
+description = "an even-sized word"

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
+
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
+
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
+
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
+
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
+
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"

--- a/exercises/practice/run-length-encoding/.meta/tests.toml
+++ b/exercises/practice/run-length-encoding/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[ad53b61b-6ffc-422f-81a6-61f7df92a231]
+description = "run-length encode a string -> empty string"
+
+[52012823-b7e6-4277-893c-5b96d42f82de]
+description = "run-length encode a string -> single characters only are encoded without count"
+
+[b7868492-7e3a-415f-8da3-d88f51f80409]
+description = "run-length encode a string -> string with no single characters"
+
+[859b822b-6e9f-44d6-9c46-6091ee6ae358]
+description = "run-length encode a string -> single characters mixed with repeated characters"
+
+[1b34de62-e152-47be-bc88-469746df63b3]
+description = "run-length encode a string -> multiple whitespace mixed in string"
+
+[abf176e2-3fbd-40ad-bb2f-2dd6d4df721a]
+description = "run-length encode a string -> lowercase characters"
+
+[7ec5c390-f03c-4acf-ac29-5f65861cdeb5]
+description = "run-length decode a string -> empty string"
+
+[ad23f455-1ac2-4b0e-87d0-b85b10696098]
+description = "run-length decode a string -> single characters only"
+
+[21e37583-5a20-4a0e-826c-3dee2c375f54]
+description = "run-length decode a string -> string with no single characters"
+
+[1389ad09-c3a8-4813-9324-99363fba429c]
+description = "run-length decode a string -> single characters with repeated characters"
+
+[3f8e3c51-6aca-4670-b86c-a213bf4706b0]
+description = "run-length decode a string -> multiple whitespace mixed in string"
+
+[29f721de-9aad-435f-ba37-7662df4fb551]
+description = "run-length decode a string -> lowercase string"
+
+[2a762efd-8695-4e04-b0d6-9736899fbc16]
+description = "encode and then decode -> encode followed by decode gives original string"

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[7ae7a46a-d992-4c2a-9c15-a112d125ebad]
+description = "slices of one from one"
+
+[3143b71d-f6a5-4221-aeae-619f906244d2]
+description = "slices of one from two"
+
+[dbb68ff5-76c5-4ccd-895a-93dbec6d5805]
+description = "slices of two"
+
+[19bbea47-c987-4e11-a7d1-e103442adf86]
+description = "slices of two overlap"
+
+[8e17148d-ba0a-4007-a07f-d7f87015d84c]
+description = "slices can include duplicates"
+
+[bd5b085e-f612-4f81-97a8-6314258278b0]
+description = "slices of a long series"
+
+[6d235d85-46cf-4fae-9955-14b6efef27cd]
+description = "slice length is too large"
+
+[d34004ad-8765-4c09-8ba1-ada8ce776806]
+description = "slice length cannot be zero"
+
+[10ab822d-8410-470a-a85d-23fbeb549e54]
+description = "slice length cannot be negative"
+
+[c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2]
+description = "empty series is invalid"

--- a/exercises/practice/spiral-matrix/.meta/tests.toml
+++ b/exercises/practice/spiral-matrix/.meta/tests.toml
@@ -1,0 +1,28 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[8f584201-b446-4bc9-b132-811c8edd9040]
+description = "empty spiral"
+
+[e40ae5f3-e2c9-4639-8116-8a119d632ab2]
+description = "trivial spiral"
+
+[cf05e42d-eb78-4098-a36e-cdaf0991bc48]
+description = "spiral of size 2"
+
+[1c475667-c896-4c23-82e2-e033929de939]
+description = "spiral of size 3"
+
+[05ccbc48-d891-44f5-9137-f4ce462a759d]
+description = "spiral of size 4"
+
+[f4d2165b-1738-4e0c-bed0-c459045ae50d]
+description = "spiral of size 5"

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -1,0 +1,67 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[8b2c43ac-7257-43f9-b552-7631a91988af]
+description = "equilateral triangle -> all sides are equal"
+
+[33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
+description = "equilateral triangle -> any side is unequal"
+
+[c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
+description = "equilateral triangle -> no sides are equal"
+
+[16e8ceb0-eadb-46d1-b892-c50327479251]
+description = "equilateral triangle -> all zero sides is not a triangle"
+
+[3022f537-b8e5-4cc1-8f12-fd775827a00c]
+description = "equilateral triangle -> sides may be floats"
+
+[cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
+description = "isosceles triangle -> last two sides are equal"
+
+[e388ce93-f25e-4daf-b977-4b7ede992217]
+description = "isosceles triangle -> first two sides are equal"
+
+[d2080b79-4523-4c3f-9d42-2da6e81ab30f]
+description = "isosceles triangle -> first and last sides are equal"
+
+[8d71e185-2bd7-4841-b7e1-71689a5491d8]
+description = "isosceles triangle -> equilateral triangles are also isosceles"
+
+[840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
+description = "isosceles triangle -> no sides are equal"
+
+[2eba0cfb-6c65-4c40-8146-30b608905eae]
+description = "isosceles triangle -> first triangle inequality violation"
+
+[278469cb-ac6b-41f0-81d4-66d9b828f8ac]
+description = "isosceles triangle -> second triangle inequality violation"
+
+[90efb0c7-72bb-4514-b320-3a3892e278ff]
+description = "isosceles triangle -> third triangle inequality violation"
+
+[adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
+description = "isosceles triangle -> sides may be floats"
+
+[e8b5f09c-ec2e-47c1-abec-f35095733afb]
+description = "scalene triangle -> no sides are equal"
+
+[2510001f-b44d-4d18-9872-2303e7977dc1]
+description = "scalene triangle -> all sides are equal"
+
+[c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
+description = "scalene triangle -> two sides are equal"
+
+[70ad5154-0033-48b7-af2c-b8d739cd9fdc]
+description = "scalene triangle -> may not violate triangle inequality"
+
+[26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
+description = "scalene triangle -> sides may be floats"

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -1,0 +1,19 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce]
+description = "no name given"
+
+[b4c6dbb8-b4fb-42c2-bafd-10785abe7709]
+description = "a name given"
+
+[3549048d-1a6e-4653-9a79-b0bda163e8d5]
+description = "another name given"

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -1,0 +1,49 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[61559d5f-2cad-48fb-af53-d3973a9ee9ef]
+description = "count one word"
+
+[5abd53a3-1aed-43a4-a15a-29f88c09cbbd]
+description = "count one of each word"
+
+[2a3091e5-952e-4099-9fac-8f85d9655c0e]
+description = "multiple occurrences of a word"
+
+[e81877ae-d4da-4af4-931c-d923cd621ca6]
+description = "handles cramped lists"
+
+[7349f682-9707-47c0-a9af-be56e1e7ff30]
+description = "handles expanded lists"
+
+[a514a0f2-8589-4279-8892-887f76a14c82]
+description = "ignore punctuation"
+
+[d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e]
+description = "include numbers"
+
+[dac6bc6a-21ae-4954-945d-d7f716392dbf]
+description = "normalize case"
+
+[4185a902-bdb0-4074-864c-f416e42a0f19]
+description = "with apostrophes"
+
+[be72af2b-8afe-4337-b151-b297202e4a7b]
+description = "with quotations"
+
+[8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6]
+description = "substrings from the beginning"
+
+[c5f4ef26-f3f7-4725-b314-855c04fb4c13]
+description = "multiple spaces not detected as a word"
+
+[50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
+description = "alternating word separators not detected as a word"


### PR DESCRIPTION
We're in the process of re-opening the [Problem Specifications repo](https://github.com/exercism/problem-specifications), as discussed in [this issue](https://github.com/exercism/problem-specifications/issues/1674).
This PR adds `.meta/tests.toml` files for all exercises for which canonical data is defined in the Problem Specifications repo.
We'll now discuss _why_ we're making this change.
## Keeping track of implemented tests
While most of the changes to the Problem Specifications repo are specific to that repo, there is one track-specific change:
> If a track implements an exercise for which test data exists, the exercise _must_ contain a `.meta/tests.toml` file.
The goal of the `tests.toml` file is to keep track of which tests are implemented by the exercise.
Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
A `tests.toml` file for a track's `two-fer` exercise looks like this:
```toml
[canonical-tests]
# no name given
"19709124-b82e-4e86-a722-9e5c5ebf3952" = true
# a name given
"3451eebd-123f-4256-b667-7b109affce32" = true
# another name given
"653611c6-be9f-4935-ab42-978e25fe9a10" = false
```
In this case, the track has chosen to implement two of the three available tests.
If a track uses a _test generator_ to generate an exercise's test suite, it _must_ use the contents of the `tests.toml` file to determine which tests to include in the generated test suite.
## Tooling
To make it easy to keep the `tests.toml` up to date, tracks can use the [`canonical_data_syncer` application](https://github.com/exercism/canonical-data-syncer).
This application is a small, standalone binary that will compare the tests specified in the `tests.toml` files against the tests that are defined in the exercise's canonical data.
It then interactively gives the maintainer the option to include or exclude test cases that are currently missing, updating the `tests.toml` file accordingly.
To use the canonical data syncer tool, tracks should copying the [`fetch-canonical_data_syncer`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer) and/or [`fetch-canonical_data_syncer.ps1`](https://github.com/exercism/canonical-data-syncer/blob/master/scripts/fetch-canonical_data_syncer.ps1) scripts into their repository.
Then, running either of these scripts will download the latest version of the tool to the track's `bin` directory.
The tool can be run using `./bin/canonical_data_syncer` or `.\bin\canonical_data_syncer.exe`, depending on your operating system.
## Changes
In this PR, we're adding `meta/tests.toml` files for all the exercises for which canonical data is defined.
We've initially marked all tests as _included_, which means that we'll assume that your track has implemented those tests.
If there isn't anything obviously wrong with the PR, I would suggest to merge this PR first, and then later on update the `meta/tests.toml` files according to your track's actual implementation.
