### PR TITLE
Upgrade cljs-test-runner used in exercises

### DIFF
--- a/exercises/anagram/deps.edn
+++ b/exercises/anagram/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/armstrong-numbers/deps.edn
+++ b/exercises/armstrong-numbers/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/beer-song/deps.edn
+++ b/exercises/beer-song/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/bob/deps.edn
+++ b/exercises/bob/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/clock/deps.edn
+++ b/exercises/clock/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/hamming/deps.edn
+++ b/exercises/hamming/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/hello-world/deps.edn
+++ b/exercises/hello-world/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/isbn-verifier/deps.edn
+++ b/exercises/isbn-verifier/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/isogram/deps.edn
+++ b/exercises/isogram/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/leap/deps.edn
+++ b/exercises/leap/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/nucleotide-count/deps.edn
+++ b/exercises/nucleotide-count/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/phone-number/deps.edn
+++ b/exercises/phone-number/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/raindrops/deps.edn
+++ b/exercises/raindrops/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/reverse-string/deps.edn
+++ b/exercises/reverse-string/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/rna-transcription/deps.edn
+++ b/exercises/rna-transcription/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/run-length-encoding/deps.edn
+++ b/exercises/run-length-encoding/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/series/deps.edn
+++ b/exercises/series/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/spiral-matrix/deps.edn
+++ b/exercises/spiral-matrix/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/triangle/deps.edn
+++ b/exercises/triangle/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/two-fer/deps.edn
+++ b/exercises/two-fer/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}

--- a/exercises/word-count/deps.edn
+++ b/exercises/word-count/deps.edn
@@ -6,5 +6,5 @@
  {:test
   {:extra-paths ["test"]
    :extra-deps
-   {olical/cljs-test-runner {:mvn/version "0.1.1"}}
+   {olical/cljs-test-runner {:mvn/version "3.8.0"}}
    :main-opts ["-m" "cljs-test-runner.main"]}}}


### PR DESCRIPTION
Upgrade `cljs-test-runner` to latest version (3.8.0). Enables number of
new test runner features including watch mode.