### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "501ffed8-0f7c-4634-9e90-e74dd57b80f1",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing ClojureScript locally",
+      "blurb": "Learn how to install ClojureScript locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "04ac909e-e97d-4470-bd69-07472eb9e8e2",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn ClojureScript",
+      "blurb": "An overview of how to get started from scratch with ClojureScript"
+    },
+    {
+      "uuid": "df2796d2-e095-44ae-814b-b033dcc17925",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the ClojureScript track",
+      "blurb": "Learn how to test your ClojureScript exercises on Exercism"
+    },
+    {
+      "uuid": "79ce1adf-bb95-4413-8067-3ebde7d2c5f4",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful ClojureScript resources",
+      "blurb": "A collection of useful resources to help you master ClojureScript"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
