### PR TITLE
🤖 Sync exercise files keys based on file path patterns

### DIFF
--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/anagram.cljs"
+    ],
+    "test": [
+      "test/anagram_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/armstrong_numbers.cljs"
+    ],
+    "test": [
+      "test/armstrong_numbers_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/beer-song/.meta/config.json
+++ b/exercises/practice/beer-song/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/beer_song.cljs"
+    ],
+    "test": [
+      "test/beer_song_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/bob.cljs"
+    ],
+    "test": [
+      "test/bob_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/clock/.meta/config.json
+++ b/exercises/practice/clock/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/clock.cljs"
+    ],
+    "test": [
+      "test/clock_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/hamming.cljs"
+    ],
+    "test": [
+      "test/hamming_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -7,8 +7,12 @@
     "michaelrbock"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/hello_world.cljs"
+    ],
+    "test": [
+      "test/hello_world_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/isbn-verifier/.meta/config.json
+++ b/exercises/practice/isbn-verifier/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/isbn_verifier.cljs"
+    ],
+    "test": [
+      "test/isbn_verifier_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/isogram.cljs"
+    ],
+    "test": [
+      "test/isogram_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/leap.cljs"
+    ],
+    "test": [
+      "test/leap_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/nucleotide_count.cljs"
+    ],
+    "test": [
+      "test/nucleotide_count_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/phone_number.cljs"
+    ],
+    "test": [
+      "test/phone_number_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/raindrops.cljs"
+    ],
+    "test": [
+      "test/raindrops_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/reverse_string.cljs"
+    ],
+    "test": [
+      "test/reverse_string_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/rna_transcription.cljs"
+    ],
+    "test": [
+      "test/rna_transcription_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/run_length_encoding.cljs"
+    ],
+    "test": [
+      "test/run_length_encoding_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/series.cljs"
+    ],
+    "test": [
+      "test/series_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/spiral_matrix.cljs"
+    ],
+    "test": [
+      "test/spiral_matrix_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/triangle.cljs"
+    ],
+    "test": [
+      "test/triangle_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -8,8 +8,12 @@
     "michaelrbock"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/two_fer.cljs"
+    ],
+    "test": [
+      "test/two_fer_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -7,8 +7,12 @@
     "iiska"
   ],
   "files": {
-    "solution": [],
-    "test": [],
+    "solution": [
+      "src/word_count.cljs"
+    ],
+    "test": [
+      "test/word_count_test.cljs"
+    ],
     "example": [
       ".meta/src/example.cljs"
     ]


### PR DESCRIPTION
To help tracks define the files in the exercise's `.meta/config.json` file, we've added support for defining these file patterns in the track's `config.json` file. See [this PR](https://github.com/exercism/docs/pull/58).

This PR updates the file paths defined in the `files` property of each exercise's `.meta/config.json` file according to the file patterns defined in the track's `config.json` file.

We only update a file path in the `.meta/config.json` file if:

- The file path pattern is a non-empty array in the `config.json` file
- The file path pattern is either not set or an empty array in the `.meta/config.json` file

This means that exercises that had already defined files in the `.meta/config.json` won't be touched in this PR.

Note that this PR is just an easy way for tracks to populate the files in the `.meta/config.json` files. Tracks are completely free to add/change/remove the files in their `.meta/config.json` files.

In the future, we'll update `configlet` to include this functionality. If you'd like me to re-run the script because changes have been made, feel free to ping me on Slack (@erikschierboom).

## Tracking

https://github.com/exercism/v3-launch/issues/20

