### PR TITLE
🤖 Add stub files to all exercises

### DIFF
--- a/exercises/practice/binary-search-tree/.meta/config.json
+++ b/exercises/practice/binary-search-tree/.meta/config.json
@@ -3,10 +3,10 @@
   "authors": [],
   "files": {
     "solution": [
-      "src/{snake_slug}.cljs"
+      "src/binary_search_tree.cljs"
     ],
     "test": [
-      "test/{snake_slug}_test.cljs"
+      "test/binary_search_tree_test.cljs"
     ],
     "example": [
       "src/example.cljs"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -3,10 +3,10 @@
   "authors": [],
   "files": {
     "solution": [
-      "src/{snake_slug}.cljs"
+      "src/binary_search.cljs"
     ],
     "test": [
-      "test/{snake_slug}_test.cljs"
+      "test/binary_search_test.cljs"
     ],
     "example": [
       "src/example.cljs"

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -3,13 +3,13 @@
   "authors": [],
   "files": {
     "solution": [
-      "src/{snake_slug}.cljs"
+      "src/matching_brackets.cljs"
     ],
     "test": [
-      "test/{snake_slug}_test.cljs"
+      "test/matching_brackets_test.cljs"
     ],
     "example": [
-      "src/example.clj"
+      "src/example.cljs"
     ]
   },
   "source": "Ginna Baker"

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -3,10 +3,10 @@
   "authors": [],
   "files": {
     "solution": [
-      "src/{snake_slug}.cljs"
+      "src/pascals_triangle.cljs"
     ],
     "test": [
-      "test/{snake_slug}_test.cljs"
+      "test/pascals_triangle_test.cljs"
     ],
     "example": [
       "src/example-traditional.cljs",


### PR DESCRIPTION
In this PR, we created (empty) stub files for all exercises that didn't yet have them.

The lack of stub file generates an unnecessary pain point within Exercism, contributing a significant proportion of support requests, making things more complex for our students, and hindering our ability to automatically run test-suites and provide automated analysis of solutions.

The original discussion for this is at exercism/discussions#238.

**We will automatically merge this PR in two week's time if it has not been merged by track maintainers at that point :slightly_smiling_face:**

## Tracking

https://github.com/exercism/v3-launch/issues/33
