### PR TITLE
wrong test case

### DIFF
--- a/exercises/practice/phone-number/test/phone_number_test.cljs
+++ b/exercises/practice/phone-number/test/phone_number_test.cljs
@@ -3,7 +3,7 @@
             [cljs.test :refer [deftest testing is] :as t :include-macros true]))
 
 (deftest cleans-number
-  (is (= "1234567890" (phone-number/number "(123) 456-7890"))))
+  (is (= "2345678901" (phone-number/number "(234) 567-8901"))))
 
 (deftest cleans-number-with-dots
   (is (= "5558675309" (phone-number/number "555.867.5309"))))


### PR DESCRIPTION
Given the definition of a valid phone number, the area code cannot start with `1`. Given the later tests, number should return `0000000000` or, as I am proposing, the phone number to be validated should be corrected.