### PR TITLE
Remove personal choice items from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
-*.swp
-.DS_Store
 bin/configlet
 bin/configlet.exe


### PR DESCRIPTION
Operating system and editor artifacts that are not generated by this
project should be maintained by "not us".
