### PR TITLE
Fix deprecation warning

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -39,7 +39,7 @@ Ran 14 tests containing 14 assertions.
 
 To run an exercise's tests with Clojure CLI, simply call:
 ``` bash
-$ clojure -A:test
+$ clojure -M:test
 
 Testing bob-tests
 

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -3,7 +3,7 @@
 To use the CLI to run the exercise's test, run the following command from the exercise's directory:
 
 ```bash
-clojure -A:test
+clojure -M:test
 ```
 
 ## REPL


### PR DESCRIPTION
> WARNING: Use of :main-opts with -A is deprecated. Use -M instead.
