### PR TITLE
Use cljs.test with consistent alias

### DIFF
--- a/exercises/practice/accumulate/test/accumulate_test.cljs
+++ b/exercises/practice/accumulate/test/accumulate_test.cljs
@@ -1,5 +1,6 @@
 (ns accumulate-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
+            [clojure.string :refer [upper-case]]
             accumulate))
 
 (defn- square [n] (* n n))
@@ -15,7 +16,7 @@
 (deftest accumulate-upcases
   (is (= ["HELLO", "WORLD"]
          (->> ["hello" "world"]
-              (accumulate/accumulate clojure.string/upper-case)
+              (accumulate/accumulate upper-case)
               (map to-s)))))
 
 (deftest accumulate-reversed-strings

--- a/exercises/practice/acronym/test/acronym_test.cljs
+++ b/exercises/practice/acronym/test/acronym_test.cljs
@@ -1,5 +1,5 @@
 (ns acronym-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             acronym))
 
 (deftest test-acronym-empty-string

--- a/exercises/practice/all-your-base/test/all_your_base_test.cljs
+++ b/exercises/practice/all-your-base/test/all_your_base_test.cljs
@@ -1,5 +1,5 @@
 (ns all-your-base-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [cljs.test :refer [deftest is testing] :as t :include-macros true]
             [all-your-base]))
 
 (deftest test-single-bit-to-one-decimal

--- a/exercises/practice/atbash-cipher/test/atbash_cipher_test.cljs
+++ b/exercises/practice/atbash-cipher/test/atbash_cipher_test.cljs
@@ -1,5 +1,5 @@
 (ns atbash-cipher-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             atbash-cipher))
 
 (deftest encode-no

--- a/exercises/practice/bank-account/test/bank_account_test.cljs
+++ b/exercises/practice/bank-account/test/bank_account_test.cljs
@@ -1,6 +1,6 @@
 (ns bank-account-test
   (:require
-   [clojure.test :refer [deftest testing is use-fixtures]]
+   [cljs.test :refer [deftest is testing] :as t :include-macros true]
    [bank-account]))
 
 (defn pcalls
@@ -11,8 +11,8 @@
   [& fns] (pmap #(%) fns))
 
 #_(defn shutdown-agents-fixture [f]
-  (f)
-  (shutdown-agents))
+    (f)
+    (shutdown-agents))
 
 ;(use-fixtures :once shutdown-agents-fixture)
 

--- a/exercises/practice/change/test/change_test.cljs
+++ b/exercises/practice/change/test/change_test.cljs
@@ -1,5 +1,5 @@
 (ns change-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             [change :refer [issue]]))
 
 (deftest single-coin-change
@@ -27,12 +27,12 @@
 
 (deftest error-testing-for-change-smallet-than-the-smallest-coin
   (is (thrown? js/Error #"cannot change"
-                        (issue 3 #{5 10}))))
+               (issue 3 #{5 10}))))
 
 (deftest cannot-find-negative-change-values
   (is (thrown? js/Error #"cannot change"
-                        (issue -5 #{1 2 5}))))
+               (issue -5 #{1 2 5}))))
 
 (deftest error-testing-for-no-valid-change
   (is (thrown? js/Error #"cannot change"
-                        (issue 10 #{20 8 3}))))
+               (issue 10 #{20 8 3}))))

--- a/exercises/practice/collatz-conjecture/test/collatz_conjecture_test.cljs
+++ b/exercises/practice/collatz-conjecture/test/collatz_conjecture_test.cljs
@@ -1,5 +1,5 @@
 (ns collatz-conjecture-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [cljs.test :refer [deftest is testing] :as t :include-macros true]
             [collatz-conjecture :refer [collatz]]))
 
 (deftest steps-for-1

--- a/exercises/practice/complex-numbers/test/complex_numbers_test.cljs
+++ b/exercises/practice/complex-numbers/test/complex_numbers_test.cljs
@@ -1,5 +1,5 @@
 (ns complex-numbers-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [cljs.test :refer [deftest is testing] :as t :include-macros true]
             [complex-numbers :as c]))
 
 ;; Tests for Real Part

--- a/exercises/practice/crypto-square/test/crypto_square_test.cljs
+++ b/exercises/practice/crypto-square/test/crypto_square_test.cljs
@@ -1,5 +1,5 @@
 (ns crypto-square-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             crypto-square))
 
 (deftest normalize-splunk

--- a/exercises/practice/diamond/test/diamond_test.cljs
+++ b/exercises/practice/diamond/test/diamond_test.cljs
@@ -1,5 +1,5 @@
 (ns diamond-test
-  (:require [clojure.test :refer [deftest is are]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             [diamond :refer [diamond]]))
 
 (deftest single-a-row

--- a/exercises/practice/difference-of-squares/test/difference_of_squares_test.cljs
+++ b/exercises/practice/difference-of-squares/test/difference_of_squares_test.cljs
@@ -1,5 +1,5 @@
 (ns difference-of-squares-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             [difference-of-squares :as dos]))
 
 (deftest square-of-sum-to-5

--- a/exercises/practice/etl/test/etl_test.cljs
+++ b/exercises/practice/etl/test/etl_test.cljs
@@ -1,5 +1,5 @@
 (ns etl-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             etl))
 
 (deftest transform-one-value

--- a/exercises/practice/flatten-array/test/flatten_array_test.cljs
+++ b/exercises/practice/flatten-array/test/flatten_array_test.cljs
@@ -1,5 +1,5 @@
 (ns flatten-array-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [cljs.test :refer [deftest is testing] :as t :include-macros true]
             [flatten-array]))
 
 (deftest flattens-array-of-ints

--- a/exercises/practice/gigasecond/test/gigasecond_test.cljs
+++ b/exercises/practice/gigasecond/test/gigasecond_test.cljs
@@ -1,5 +1,5 @@
 (ns gigasecond-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             gigasecond))
 
 (deftest from-apr-25-2011

--- a/exercises/practice/go-counting/test/go_counting_test.cljs
+++ b/exercises/practice/go-counting/test/go_counting_test.cljs
@@ -1,5 +1,5 @@
 (ns go-counting-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             [go-counting :as g]))
 
 (def example

--- a/exercises/practice/grade-school/test/grade_school_test.cljs
+++ b/exercises/practice/grade-school/test/grade_school_test.cljs
@@ -1,5 +1,5 @@
 (ns grade-school-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             grade-school))
 
 (def db {})

--- a/exercises/practice/grains/test/grains_test.cljs
+++ b/exercises/practice/grains/test/grains_test.cljs
@@ -1,5 +1,5 @@
 (ns grains-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             grains))
 
 (deftest square-1

--- a/exercises/practice/kindergarten-garden/test/kindergarten_garden_test.cljs
+++ b/exercises/practice/kindergarten-garden/test/kindergarten_garden_test.cljs
@@ -1,5 +1,5 @@
 (ns kindergarten-garden-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             kindergarten-garden))
 
 (deftest garden-test

--- a/exercises/practice/meetup/test/meetup_test.cljs
+++ b/exercises/practice/meetup/test/meetup_test.cljs
@@ -1,5 +1,5 @@
 (ns meetup-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             meetup))
 
 (deftest monteenth-of-may-2013

--- a/exercises/practice/minesweeper/test/minesweeper_test.cljs
+++ b/exercises/practice/minesweeper/test/minesweeper_test.cljs
@@ -1,5 +1,5 @@
 (ns minesweeper-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             [clojure.string :refer [join]]
             [minesweeper :refer [draw]]))
 
@@ -59,4 +59,3 @@
                                "*****"
                                "25*52"
                                " 2*2 "]))))
-

--- a/exercises/practice/nth-prime/test/nth_prime_test.cljs
+++ b/exercises/practice/nth-prime/test/nth_prime_test.cljs
@@ -1,5 +1,5 @@
 (ns nth-prime-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [cljs.test :refer [deftest is testing] :as t :include-macros true]
             nth-prime))
 
 (deftest first-prime

--- a/exercises/practice/perfect-numbers/test/perfect_numbers_test.cljs
+++ b/exercises/practice/perfect-numbers/test/perfect_numbers_test.cljs
@@ -1,6 +1,6 @@
 (ns perfect-numbers-test
   (:require
-   [clojure.test :refer [deftest testing is]]
+   [cljs.test :refer [deftest is testing] :as t :include-macros true]
    [perfect-numbers]))
 
 (deftest test-initialize-perfect-number

--- a/exercises/practice/pig-latin/test/pig_latin_test.cljs
+++ b/exercises/practice/pig-latin/test/pig_latin_test.cljs
@@ -1,5 +1,5 @@
 (ns pig-latin-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             pig-latin))
 
 ;; ay is added to words that start with vowels

--- a/exercises/practice/poker/test/poker_test.cljs
+++ b/exercises/practice/poker/test/poker_test.cljs
@@ -1,5 +1,5 @@
 (ns poker-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             [poker :refer [best-hands]]))
 
 (defn f [xs ys] (= (sort (best-hands xs)) (sort ys)))

--- a/exercises/practice/pov/test/pov_test.cljs
+++ b/exercises/practice/pov/test/pov_test.cljs
@@ -1,5 +1,5 @@
 (ns pov-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             pov))
 
 ;;; Inputs.

--- a/exercises/practice/prime-factors/test/prime_factors_test.cljs
+++ b/exercises/practice/prime-factors/test/prime_factors_test.cljs
@@ -1,5 +1,5 @@
 (ns prime-factors-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             prime-factors))
 
 (deftest one

--- a/exercises/practice/protein-translation/test/protein_translation_test.cljs
+++ b/exercises/practice/protein-translation/test/protein_translation_test.cljs
@@ -1,5 +1,5 @@
 (ns protein-translation-test
-  (:require [clojure.test :refer [deftest is are]]
+  (:require [cljs.test :refer [deftest is are] :as t :include-macros true]
             protein-translation))
 
 (deftest AUG-translates-to-Methionine

--- a/exercises/practice/proverb/test/proverb_test.cljs
+++ b/exercises/practice/proverb/test/proverb_test.cljs
@@ -1,30 +1,30 @@
 (ns proverb-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             [proverb :refer [recite]]
             [clojure.string :as str]))
 
 (deftest zero-pieces
   (is (=
-        (recite ())
-        "")))
-      
+       (recite ())
+       "")))
+
 (deftest one-piece
   (is (=
-        (recite '("nail"))
-        "And all for the want of a nail.")))
+       (recite '("nail"))
+       "And all for the want of a nail.")))
 
 (deftest two-pieces
   (is (=
-        (recite '("nail" "shoe"))
-        (str/join "\n" ["For want of a nail the shoe was lost."
-                        "And all for the want of a nail."]))))
+       (recite '("nail" "shoe"))
+       (str/join "\n" ["For want of a nail the shoe was lost."
+                       "And all for the want of a nail."]))))
 
 (deftest three-pieces
   (is (=
-        (recite '("nail" "shoe" "horse"))
-        (str/join "\n" ["For want of a nail the shoe was lost."
-                        "For want of a shoe the horse was lost."
-                        "And all for the want of a nail."]))))
+       (recite '("nail" "shoe" "horse"))
+       (str/join "\n" ["For want of a nail the shoe was lost."
+                       "For want of a shoe the horse was lost."
+                       "And all for the want of a nail."]))))
 
 (deftest full-proverb
   (is (= (recite '("nail" "shoe" "horse" "rider" "message" "battle" "kingdom"))
@@ -38,8 +38,8 @@
 
 (deftest four-pieces-modernized
   (is (=
-        (recite '("pin" "gun" "soldier" "battle"))
-        (str/join "\n" ["For want of a pin the gun was lost."
-                        "For want of a gun the soldier was lost."
-                        "For want of a soldier the battle was lost."
-                        "And all for the want of a pin."]))))
+       (recite '("pin" "gun" "soldier" "battle"))
+       (str/join "\n" ["For want of a pin the gun was lost."
+                       "For want of a gun the soldier was lost."
+                       "For want of a soldier the battle was lost."
+                       "And all for the want of a pin."]))))

--- a/exercises/practice/queen-attack/test/queen_attack_test.cljs
+++ b/exercises/practice/queen-attack/test/queen_attack_test.cljs
@@ -1,5 +1,5 @@
 (ns queen-attack-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             queen-attack))
 
 (def empty-board

--- a/exercises/practice/robot-name/test/robot_name_test.cljs
+++ b/exercises/practice/robot-name/test/robot_name_test.cljs
@@ -1,47 +1,47 @@
 (ns robot-name-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             robot-name))
 
 (deftest robot-name
   (let [a-robot (robot-name/robot)
         its-name (robot-name/robot-name a-robot)]
-      (is (re-seq #"[A-Z]{2}\d{3}" its-name))))
+    (is (re-seq #"[A-Z]{2}\d{3}" its-name))))
 
 (deftest name-matches-pattern
-   (let [a-robot (robot-name/robot)
-         its-name (robot-name/robot-name a-robot)]
-     (is (= its-name (robot-name/robot-name a-robot)))))
+  (let [a-robot (robot-name/robot)
+        its-name (robot-name/robot-name a-robot)]
+    (is (= its-name (robot-name/robot-name a-robot)))))
 
 (deftest different-robots-different-names
- (let [a-robot (robot-name/robot)
+  (let [a-robot (robot-name/robot)
         its-name (robot-name/robot-name a-robot)]
-      (is (not= its-name (-> (robot-name/robot) robot-name/robot-name)))))
+    (is (not= its-name (-> (robot-name/robot) robot-name/robot-name)))))
 
 (deftest new-name-matches
   (let [a-robot (robot-name/robot)
         its-original-name (robot-name/robot-name a-robot)
         its-new-name (do (robot-name/reset-name a-robot)
                          (robot-name/robot-name a-robot))]
-      (is (re-seq #"[A-Z]{2}\d{3}" its-new-name))))
+    (is (re-seq #"[A-Z]{2}\d{3}" its-new-name))))
 
 (deftest new-name-different
   (let [a-robot (robot-name/robot)
         its-original-name (robot-name/robot-name a-robot)
         its-new-name (do (robot-name/reset-name a-robot)
                          (robot-name/robot-name a-robot))]
-      (is (not= its-original-name its-new-name))))
+    (is (not= its-original-name its-new-name))))
 
 (deftest new-name-does-not-change-until-reset
   (let [a-robot (robot-name/robot)
         its-original-name (robot-name/robot-name a-robot)
         its-new-name (do (robot-name/reset-name a-robot)
                          (robot-name/robot-name a-robot))]
-      (is (= its-new-name (robot-name/robot-name a-robot)))))
+    (is (= its-new-name (robot-name/robot-name a-robot)))))
 
 (deftest new-names-different-each-time
   (let [a-robot (robot-name/robot)
         its-original-name (robot-name/robot-name a-robot)
         its-new-name (do (robot-name/reset-name a-robot)
                          (robot-name/robot-name a-robot))]
-  (is (not= its-new-name (do (robot-name/reset-name a-robot)
-                             (robot-name/robot-name a-robot))))))
+    (is (not= its-new-name (do (robot-name/reset-name a-robot)
+                               (robot-name/robot-name a-robot))))))

--- a/exercises/practice/robot-simulator/test/robot_simulator_test.cljs
+++ b/exercises/practice/robot-simulator/test/robot_simulator_test.cljs
@@ -1,5 +1,5 @@
 (ns robot-simulator-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             robot-simulator))
 
 (def robbie (robot-simulator/robot {:x -2 :y 1} :east))

--- a/exercises/practice/roman-numerals/test/roman_numerals_test.cljs
+++ b/exercises/practice/roman-numerals/test/roman_numerals_test.cljs
@@ -1,5 +1,5 @@
 (ns roman-numerals-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             roman-numerals))
 
 (deftest one

--- a/exercises/practice/rotational-cipher/test/rotational_cipher_test.cljs
+++ b/exercises/practice/rotational-cipher/test/rotational_cipher_test.cljs
@@ -1,5 +1,5 @@
 (ns rotational-cipher-test
-  (:require  [clojure.test :refer [deftest is testing]]
+  (:require  [cljs.test :refer [deftest is] :as t :include-macros true]
              rotational-cipher))
 
 (deftest rotate-a-by-1

--- a/exercises/practice/say/test/say_test.cljs
+++ b/exercises/practice/say/test/say_test.cljs
@@ -1,5 +1,5 @@
 (ns say-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             say))
 
 (deftest zero-test

--- a/exercises/practice/scrabble-score/test/scrabble_score_test.cljs
+++ b/exercises/practice/scrabble-score/test/scrabble_score_test.cljs
@@ -1,5 +1,5 @@
 (ns scrabble-score-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             scrabble-score))
 
 (deftest lower-case-letter

--- a/exercises/practice/secret-handshake/test/secret_handshake_test.cljs
+++ b/exercises/practice/secret-handshake/test/secret_handshake_test.cljs
@@ -1,5 +1,5 @@
 (ns secret-handshake-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [cljs.test :refer [deftest is testing] :as t :include-macros true]
             secret-handshake))
 
 (deftest wink

--- a/exercises/practice/sieve/test/sieve_test.cljs
+++ b/exercises/practice/sieve/test/sieve_test.cljs
@@ -1,5 +1,5 @@
 (ns sieve-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             [sieve :refer [sieve]]))
 
 (deftest a-few-primes

--- a/exercises/practice/space-age/test/space_age_test.cljs
+++ b/exercises/practice/space-age/test/space_age_test.cljs
@@ -1,5 +1,5 @@
 (ns space-age-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             space-age))
 
 (defn- rounds-to

--- a/exercises/practice/strain/test/strain_test.cljs
+++ b/exercises/practice/strain/test/strain_test.cljs
@@ -1,5 +1,5 @@
 (ns strain-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             [strain :refer [retain discard]]))
 
 (defn- fn-throw-exception [msg] (fn [& _] (throw (Exception. msg))))

--- a/exercises/practice/strain/test/strain_test.cljs
+++ b/exercises/practice/strain/test/strain_test.cljs
@@ -2,7 +2,7 @@
   (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             [strain :refer [retain discard]]))
 
-(defn- fn-throw-exception [msg] (fn [& _] (throw (Exception. msg))))
+(defn- fn-throw-exception [msg] (fn [& _] (throw (js/Error. msg))))
 
 (deftest empty-sequence
   (is (empty? (retain even? '()))))

--- a/exercises/practice/sublist/test/sublist_test.cljs
+++ b/exercises/practice/sublist/test/sublist_test.cljs
@@ -1,54 +1,54 @@
 (ns sublist-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             sublist))
 
 (deftest empty-lists-test
-    (is (= :equal (sublist/classify [] []))))
+  (is (= :equal (sublist/classify [] []))))
 
 (deftest empty-list-within-non-empty-list-test
-    (is (= :sublist (sublist/classify [] [1 2 3]))))
+  (is (= :sublist (sublist/classify [] [1 2 3]))))
 
 (deftest non-empty-list-contains-empty-list-test
-    (is (= :superlist (sublist/classify [1 2 3] []))))
+  (is (= :superlist (sublist/classify [1 2 3] []))))
 
 (deftest list-equals-itself-test
-    (is (= :equal (sublist/classify [1 2 3] [1 2 3]))))
+  (is (= :equal (sublist/classify [1 2 3] [1 2 3]))))
 
 (deftest different-lists
-    (is (= :unequal (sublist/classify [1 2 3] [2 3 4]))))
+  (is (= :unequal (sublist/classify [1 2 3] [2 3 4]))))
 
 (deftest false-start
-    (is (= :sublist (sublist/classify [1 2 5] [0 1 2 3 1 2 5 6]))))
+  (is (= :sublist (sublist/classify [1 2 5] [0 1 2 3 1 2 5 6]))))
 
 (deftest consecutive
-    (is (= :sublist (sublist/classify [1 1 2] [0 1 1 1 2 1 2]))))
+  (is (= :sublist (sublist/classify [1 1 2] [0 1 1 1 2 1 2]))))
 
 (deftest sublist-at-start
-    (is (= :sublist (sublist/classify [0 1 2] [0 1 2 3 4 5]))))
+  (is (= :sublist (sublist/classify [0 1 2] [0 1 2 3 4 5]))))
 
 (deftest sublist-in-middle
-    (is (= :sublist (sublist/classify [2 3 4] [0 1 2 3 4 5]))))
+  (is (= :sublist (sublist/classify [2 3 4] [0 1 2 3 4 5]))))
 
 (deftest sublist-at-end
-    (is (= :sublist (sublist/classify [3 4 5] [0 1 2 3 4 5]))))
+  (is (= :sublist (sublist/classify [3 4 5] [0 1 2 3 4 5]))))
 
 (deftest at-start-of-superlist
-    (is (= :superlist (sublist/classify [0 1 2 3 4 5] [0 1 2]))))
+  (is (= :superlist (sublist/classify [0 1 2 3 4 5] [0 1 2]))))
 
 (deftest in-middle-of-superlist
-    (is (= :superlist (sublist/classify [0 1 2 3 4 5] [2 3]))))
+  (is (= :superlist (sublist/classify [0 1 2 3 4 5] [2 3]))))
 
 (deftest at-end-of-superlist
-    (is (= :superlist (sublist/classify [0 1 2 3 4 5] [3 4 5]))))
+  (is (= :superlist (sublist/classify [0 1 2 3 4 5] [3 4 5]))))
 
 (deftest first-list-missing-element-from-second-list
-    (is (= :unequal (sublist/classify [1 3] [1 2 3]))))
+  (is (= :unequal (sublist/classify [1 3] [1 2 3]))))
 
 (deftest second-list-missing-element-from-first-list
-    (is (= :unequal (sublist/classify [1 2 3] [1 3]))))
+  (is (= :unequal (sublist/classify [1 2 3] [1 3]))))
 
 (deftest order-matters-to-a-list
-    (is (= :unequal (sublist/classify [1 2 3] [3 2 1]))))
+  (is (= :unequal (sublist/classify [1 2 3] [3 2 1]))))
 
 (deftest same-digits-but-different-numbers
-    (is (= :unequal (sublist/classify [1 0 1] [10 1]))))
+  (is (= :unequal (sublist/classify [1 0 1] [10 1]))))

--- a/exercises/practice/sum-of-multiples/test/sum_of_multiples_test.cljs
+++ b/exercises/practice/sum-of-multiples/test/sum_of_multiples_test.cljs
@@ -1,5 +1,5 @@
 (ns sum-of-multiples-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             sum-of-multiples))
 
 (deftest sum-to-1

--- a/exercises/practice/wordy/test/wordy_test.cljs
+++ b/exercises/practice/wordy/test/wordy_test.cljs
@@ -1,5 +1,5 @@
 (ns wordy-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is] :as t :include-macros true]
             wordy))
 
 (deftest addition
@@ -53,4 +53,3 @@
   (is (thrown?
        js/Error
        (wordy/evaluate "Who is the President of the United States?"))))
-

--- a/exercises/practice/yacht/test/yacht_test.cljs
+++ b/exercises/practice/yacht/test/yacht_test.cljs
@@ -1,67 +1,66 @@
 (ns yacht-test
-  (:require [clojure.test :refer [deftest testing is run-tests]]
-             yacht))
+  (:require [cljs.test :refer [deftest is testing run-tests] :as t :include-macros true]
+            yacht))
 
 (deftest score-test
   (testing "Yacht"
-     (is (= 50 (yacht/score [5 5 5 5 5] "yacht"))))
+    (is (= 50 (yacht/score [5 5 5 5 5] "yacht"))))
   (testing "Not Yacht"
-     (is (= 0 (yacht/score [1 3 3 2 5] "yacht"))))
+    (is (= 0 (yacht/score [1 3 3 2 5] "yacht"))))
   (testing "Ones"
-     (is (= 3 (yacht/score [1 1 1 3 5] "ones"))))
+    (is (= 3 (yacht/score [1 1 1 3 5] "ones"))))
   (testing "Ones, out of order"
-     (is (= 3 (yacht/score [3 1 1 5 1] "ones"))))
+    (is (= 3 (yacht/score [3 1 1 5 1] "ones"))))
   (testing "No ones"
-     (is (= 0 (yacht/score [4 3 6 5 5] "ones"))))
+    (is (= 0 (yacht/score [4 3 6 5 5] "ones"))))
   (testing "Twos"
-     (is (= 2 (yacht/score [2 3 4 5 6] "twos"))))
+    (is (= 2 (yacht/score [2 3 4 5 6] "twos"))))
   (testing "Fours"
-     (is (= 8 (yacht/score [1 4 1 4 1] "fours"))))
+    (is (= 8 (yacht/score [1 4 1 4 1] "fours"))))
   (testing "Yacht counted as threes"
-     (is (= 15 (yacht/score [3 3 3 3 3] "threes"))))
+    (is (= 15 (yacht/score [3 3 3 3 3] "threes"))))
   (testing "Yacht of 3s counted as fives"
-     (is (= 0 (yacht/score [3 3 3 3 3] "fives"))))
+    (is (= 0 (yacht/score [3 3 3 3 3] "fives"))))
   (testing "Fives"
-     (is (= 10 (yacht/score [1 5 3 5 3] "fives"))))
+    (is (= 10 (yacht/score [1 5 3 5 3] "fives"))))
   (testing "Sixes"
-     (is (= 6 (yacht/score [2 3 4 5 6] "sixes"))))
+    (is (= 6 (yacht/score [2 3 4 5 6] "sixes"))))
   (testing "Full house two small, three big"
-     (is (= 16 (yacht/score [2 2 4 4 4] "full house"))))
+    (is (= 16 (yacht/score [2 2 4 4 4] "full house"))))
   (testing "Full house three small, two big"
-     (is (= 19 (yacht/score [5 3 3 5 3] "full house"))))
+    (is (= 19 (yacht/score [5 3 3 5 3] "full house"))))
   (testing "Two pair is not a full house"
-     (is (= 0 (yacht/score [2 2 4 4 5] "full house"))))
+    (is (= 0 (yacht/score [2 2 4 4 5] "full house"))))
   (testing "Four of a kind is not a full house"
-     (is (= 0 (yacht/score [1 4 4 4 4] "full house"))))
+    (is (= 0 (yacht/score [1 4 4 4 4] "full house"))))
   (testing "Yacht is not a full house"
-     (is (= 0 (yacht/score [2 2 2 2 2] "full house"))))
+    (is (= 0 (yacht/score [2 2 2 2 2] "full house"))))
   (testing "Four of a Kind"
-     (is (= 24 (yacht/score [6 6 4 6 6] "four of a kind"))))
+    (is (= 24 (yacht/score [6 6 4 6 6] "four of a kind"))))
   (testing "Yacht can be scored as Four of a Kind"
-     (is (= 12 (yacht/score [3 3 3 3 3] "four of a kind"))))
+    (is (= 12 (yacht/score [3 3 3 3 3] "four of a kind"))))
   (testing "Full house is not Four of a Kind"
-     (is (= 0 (yacht/score [3 3 3 5 5] "four of a kind"))))
+    (is (= 0 (yacht/score [3 3 3 5 5] "four of a kind"))))
   (testing "Little Straight"
-     (is (= 30 (yacht/score [3 5 4 1 2] "little straight"))))
+    (is (= 30 (yacht/score [3 5 4 1 2] "little straight"))))
   (testing "Little Straight as Big Straight"
-     (is (= 0 (yacht/score [1 2 3 4 5] "big straight"))))
+    (is (= 0 (yacht/score [1 2 3 4 5] "big straight"))))
   (testing "Four in order but not a little straight"
-     (is (= 0 (yacht/score [1 1 2 3 4] "little straight"))))
+    (is (= 0 (yacht/score [1 1 2 3 4] "little straight"))))
   (testing "No pairs but not a little straight"
-     (is (= 0 (yacht/score [1 2 3 4 6] "little straight"))))
+    (is (= 0 (yacht/score [1 2 3 4 6] "little straight"))))
   (testing "Minimum is 1, maximum is 5, but not a little straight"
-     (is (= 0 (yacht/score [1 1 3 4 5] "little straight"))))
+    (is (= 0 (yacht/score [1 1 3 4 5] "little straight"))))
   (testing "Big Straight"
-     (is (= 30 (yacht/score [4 6 2 5 3] "big straight"))))
+    (is (= 30 (yacht/score [4 6 2 5 3] "big straight"))))
   (testing "Big Straight as little straight"
-     (is (= 0 (yacht/score [6 5 4 3 2] "little straight"))))
+    (is (= 0 (yacht/score [6 5 4 3 2] "little straight"))))
   (testing "No pairs but not a big straight"
-     (is (= 0 (yacht/score [6 5 4 3 1] "big straight"))))
+    (is (= 0 (yacht/score [6 5 4 3 1] "big straight"))))
   (testing "Choice"
-     (is (= 23 (yacht/score [3 3 5 6 6] "choice"))))
+    (is (= 23 (yacht/score [3 3 5 6 6] "choice"))))
   (testing "Yacht as choice"
-     (is (= 10 (yacht/score [2 2 2 2 2] "choice")))))
+    (is (= 10 (yacht/score [2 2 2 2 2] "choice")))))
 
 (comment
-  (run-tests)
-  )
+  (run-tests))

--- a/exercises/practice/zipper/test/zipper_test.cljs
+++ b/exercises/practice/zipper/test/zipper_test.cljs
@@ -1,6 +1,6 @@
 (ns zipper-test
-  (:require [clojure.test :refer [deftest testing is run-tests]]
-             zipper))
+  (:require [cljs.test :refer [deftest is testing] :as t :include-macros true]
+            zipper))
 
 (def t1 {:value 1, :left {:value 2, :left nil, :right {:value 3, :left nil, :right nil}}, :right {:value 4, :left nil, :right nil}})
 
@@ -21,13 +21,12 @@
                    zipper/from-tree
                    zipper/left
                    zipper/right
-                   zipper/value
-                   ))))
+                   zipper/value))))
     (testing "dead end"
       (is (nil? (-> tree
-                     zipper/from-tree
-                     zipper/left
-                     zipper/left))))
+                    zipper/from-tree
+                    zipper/left
+                    zipper/left))))
     (testing "tree from deep focus"
       (is (= tree (-> tree
                       zipper/from-tree
@@ -35,12 +34,12 @@
                       zipper/right
                       zipper/to-tree))))
     (testing "traversing up from top"
-      (is (= nil 
+      (is (= nil
              (-> tree
                  zipper/from-tree
                  zipper/up))))
     (testing "left, right, and up"
-      (is (= 3 
+      (is (= 3
              (-> tree
                  zipper/from-tree
                  zipper/left
@@ -51,7 +50,7 @@
                  zipper/right
                  zipper/value))))
     (testing "test ability to descend multiple levels and return"
-      (is (= 1 
+      (is (= 1
              (-> tree
                  zipper/from-tree
                  zipper/left
@@ -68,7 +67,7 @@
                               :right nil}}
               :right {:value 4
                       :left  nil
-                      :right nil}} 
+                      :right nil}}
              (-> tree
                  zipper/from-tree
                  zipper/left
@@ -83,7 +82,7 @@
                               :right nil}}
               :right {:value 4
                       :left  nil
-                      :right nil}} 
+                      :right nil}}
              (-> tree
                  zipper/from-tree
                  zipper/left
@@ -102,7 +101,7 @@
                               :right nil}}
               :right {:value 4
                       :left  nil
-                      :right nil}} 
+                      :right nil}}
              (-> tree
                  zipper/from-tree
                  zipper/left
@@ -117,7 +116,7 @@
                       :right nil}
               :right {:value 4
                       :left  nil
-                      :right nil}} 
+                      :right nil}}
              (-> tree
                  zipper/from-tree
                  zipper/left
@@ -136,7 +135,7 @@
                               :right nil}
                       :right {:value 8
                               :left  nil
-                              :right nil}}} 
+                              :right nil}}}
              (-> tree
                  zipper/from-tree
                  (zipper/set-right {:value 6
@@ -156,7 +155,7 @@
                               :right nil}}
               :right {:value 4
                       :left  nil
-                      :right nil}} 
+                      :right nil}}
              (-> tree
                  zipper/from-tree
                  zipper/left
@@ -166,27 +165,27 @@
 
 (deftest sameResultFromOperations-test
   (testing "different paths to same zipper"
-     (is (= (-> {:value 1
-                 :left  {:value 2
-                         :left  nil
-                         :right {:value 3
-                                 :left  nil
-                                 :right nil}}
-                 :right {:value 4
-                         :left  nil
-                         :right nil}}
-                zipper/from-tree
-                zipper/right)
-         (-> {:value 1
-              :left  {:value 2
-                      :left  nil
-                      :right {:value 3
-                              :left  nil
-                              :right nil}}
-              :right {:value 4
-                      :left  nil
-                      :right nil}}
-             zipper/from-tree
-             zipper/left
-             zipper/up
-             zipper/right)))))
+    (is (= (-> {:value 1
+                :left  {:value 2
+                        :left  nil
+                        :right {:value 3
+                                :left  nil
+                                :right nil}}
+                :right {:value 4
+                        :left  nil
+                        :right nil}}
+               zipper/from-tree
+               zipper/right)
+           (-> {:value 1
+                :left  {:value 2
+                        :left  nil
+                        :right {:value 3
+                                :left  nil
+                                :right nil}}
+                :right {:value 4
+                        :left  nil
+                        :right nil}}
+               zipper/from-tree
+               zipper/left
+               zipper/up
+               zipper/right)))))


### PR DESCRIPTION
Require `cljs.test` instead of `clojure.test`, and use alias consistent with other practice exercises, to avoid test error `Could not resolve symbol: t/report` ([forum topic](https://forum.exercism.org/t/testing-new-clojurescript-exercises/5851)).