### PR TITLE
Deactivate the track

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "language": "ClojureScript",
   "slug": "clojurescript",
   "track_id": "clojurescript",
-  "active": true,
+  "active": false,
   "status": {
     "concept_exercises": false,
     "test_runner": true,


### PR DESCRIPTION
We're deactivating the track as it is basically "just" a different compile target for Clojure.
The syntactic differences between Clojure and ClojureScript are very
minor, therefore we don't consider it to merit its own track.
We feel that deactivating this track is less confusing to students _and_
can help focus efforts on the Clojure track.

Thanks to everyone who helped build this track!

CC @kytrinyx Could you archive this repo?
